### PR TITLE
DIRECT DEBIT feature added

### DIFF
--- a/NewBank/newbank/server/Customer.java
+++ b/NewBank/newbank/server/Customer.java
@@ -1,6 +1,7 @@
 package newbank.server;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 
 public class Customer {
 	
@@ -172,5 +173,38 @@ public class Customer {
         		acceptable = false;
         	}
         	return acceptable;        	
+        }
+        
+        /*Method to set up direct debit, it checks the account chosen and removes ('reserves') necessary amount 
+         * to be paid all together for the number of months selected, i.e 5 moneys over 10 months - 50 moneys minus in the account.
+         * Method start direct debit count from next month, i.e. set up in December, starts from January*/
+        public String debitSetUp(String account, String name, String amount, String months) {
+        	double debitAmount = Double.parseDouble(amount);
+        	int monthAmount = Integer.parseInt(months);
+    		String message = "";
+    		
+    		Calendar calendar = Calendar.getInstance();
+    		calendar.add(Calendar.MONTH, monthAmount);
+    		int deadline = calendar.get(Calendar.MONTH);
+    		String[] month = new String[] {"January", "February", "March", "April", "May", "June", "July", "August","September", "October", "November", "December" };
+    	    
+    	    String deadlineInText = month[calendar.get(Calendar.MONTH)];
+    	    String year = Integer.toString(calendar.get(Calendar.YEAR));
+    		
+    		for(Account a : accounts) {
+                if (account.equalsIgnoreCase(a.getCustomer())){
+                  if(a.getBalance()>= debitAmount){
+                	  for (int i=0; i<=deadline; i++){
+                		  a.removeMoney(debitAmount); 
+                	      }
+                	  message = "Direct debit set up for " + name + " until " + deadlineInText + " " + year + ".";
+                  }
+                  else {
+                	  message = "Insufficient funds.";
+                  }
+                }
+    		}
+        	return message;
+        	
         }
 }

--- a/NewBank/newbank/server/NewBank.java
+++ b/NewBank/newbank/server/NewBank.java
@@ -83,6 +83,7 @@ public class NewBank {
                             case "DEPOSIT" : return deposit(customer, commandLine.get(1), commandLine.get(2));
                             case "MOVE" : return move(customer, commandLine.get(1), commandLine.get(2), commandLine.get(3));
                             case "NEWPASSWORD" : return newPassword(customer, commandLine.get(1));
+                            case "DIRECTDEBIT" : return directDebit(customer, commandLine.get(1), commandLine.get(2), commandLine.get(3), commandLine.get(4));
                             case "INFO": return printMenuInfo();
                             }
                     }
@@ -151,6 +152,11 @@ public class NewBank {
         	return (customers.get(customer.getKey())).passwordCreate(password);        	
         }
         
+        /*Method to set up direct debit*/
+        private String directDebit(CustomerID customer, String account, String name, String amount, String months) {
+        	return (customers.get(customer.getKey())).debitSetUp(account, name, amount, months);
+        }
+        
         
         private String printMenuInfo() {
         	return "\n" + "_".repeat(85) 
@@ -172,6 +178,8 @@ public class NewBank {
     				+ "\ne.g. WITHDRAW 100"
     				+ "\n\nCLOSEACCOUNT <Name>"
     				+ "\ne.g CLOSEACCOUNT Savings"
+    				+ "\n\nDIRECTDEBIT <Account> <Person/Company> <MonthlyDebitAmount> <AmountOfMonths>"
+    				+ "\ne.g DIRECTDEBIT Main BritishGas 10 5"    				
     				+ "\n\nOBS: Use . to separate decimals"
     				+ "\n" + "_".repeat(85) +"\n";
         }

--- a/NewBank/newbank/server/NewBankClientHandler.java
+++ b/NewBank/newbank/server/NewBankClientHandler.java
@@ -74,6 +74,7 @@ public class NewBankClientHandler extends Thread{
 				+ "\n| DEPOSIT <Account> <Amount>                                                        |"
 				+ "\n| WITHRDRAW <Account> <Amount>                                                      |"
 				+ "\n| CLOSEACCOUNT <Name>                                                               |"
+				+ "\n| DIRECTDEBIT <Account> <Person/Company> <MonthlyDebitAmount> <AmountOfMonths>      |"
 				+ "\n|                                                                                   |"
 				+ "\n| If you need more information on how to use the commands, please type INFO         |"
 				+ "\n|" + "_".repeat(83) + "|\n";

--- a/NewBank/newbank/server/NewBankServer.java
+++ b/NewBank/newbank/server/NewBankServer.java
@@ -1,4 +1,4 @@
-package newbank.server;
+package newbank.server; 
 
 import java.io.IOException;
 import java.net.ServerSocket;


### PR DESCRIPTION
Method to set up direct debit, it checks the account chosen and removes ('reserves') necessary amount to be paid all together for the number of months selected, i.e 5 moneys over 10 months - 50 moneys minus in the account.

Method starts direct debit count from next month, i.e. set up in December, starts from January.